### PR TITLE
feat: add base64 execution modes and variable parsing for shell_command

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -161,12 +161,49 @@ export function UpdateActions(self: ModuleInstance): void {
 					id: 'shell',
 					label: 'Shell Command',
 					default: 'dir',
+					tooltip:
+						'The command string to execute. Quotes, environment variables, and JSON are supported automatically when Base64 mode is selected.',
+				},
+				{
+					type: 'dropdown',
+					id: 'mode',
+					label: 'Execution Mode / Encoding',
+					tooltip:
+						'Base64 encoding prevents syntax errors when commands contain double/single quotes, backslashes, or JSON payloads.',
+					description:
+						'Select CMD Base64 for Windows CMD commands (supports %USERPROFILE%, quotes, and redirects). Select PowerShell Base64 for PowerShell syntax ($env).',
+					choices: [
+						{ id: 'cmd_b64', label: 'CMD Base64 (Windows - Supports CMD syntax, %ENV%, quotes & redirects)' },
+						{ id: 'powershell_b64', label: 'PowerShell Base64 (Windows - Supports PowerShell syntax, $env)' },
+						{ id: 'bash_b64', label: 'Bash Base64 (macOS / Linux - Fixes all quotes & JSON)' },
+						{ id: 'direct', label: 'Direct / Raw (No encoding)' },
+					],
+					default: 'cmd_b64',
 				},
 			],
 			callback: async (event) => {
+				const rawShell = (event.options.shell as string) || ''
+				const shell = await self.parseVariablesInString(rawShell)
+
+				let targetCommand = shell
+				const mode = event.options.mode || 'cmd_b64'
+
+				if (mode === 'cmd_b64') {
+					const innerB64 = Buffer.from(shell, 'utf16le').toString('base64')
+					const psScript = `$b=[System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String('${innerB64}')); cmd.exe /c $b`
+					const fullB64 = Buffer.from(psScript, 'utf16le').toString('base64')
+					targetCommand = `powershell -NoProfile -NonInteractive -EncodedCommand ${fullB64}`
+				} else if (mode === 'powershell_b64') {
+					const b64 = Buffer.from(shell, 'utf16le').toString('base64')
+					targetCommand = `powershell -NoProfile -NonInteractive -EncodedCommand ${b64}`
+				} else if (mode === 'bash_b64') {
+					const b64 = Buffer.from(shell, 'utf-8').toString('base64')
+					targetCommand = `echo "${b64}" | base64 -d | bash`
+				}
+
 				self.sendCommand({
 					type: 'shellRun',
-					shell: event.options.shell,
+					shell: targetCommand,
 				})
 			},
 		},

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ export class ModuleInstance extends InstanceBase<ModuleConfig> {
 	// Send a command via the WebSocket connection.
 	sendCommand(cmd: Record<string, unknown>): void {
 		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+			this.log('debug', `Sending WebSocket command: ${JSON.stringify(cmd)}`)
 			this.socket.send(JSON.stringify(cmd))
 		} else {
 			this.log('error', 'Socket not connected')

--- a/src/upgrades.ts
+++ b/src/upgrades.ts
@@ -2,15 +2,22 @@ import type { CompanionStaticUpgradeScript } from '@companion-module/base'
 import type { ModuleConfig } from './config.js'
 
 export const UpgradeScripts: CompanionStaticUpgradeScript<ModuleConfig>[] = [
-	/*
-	 * Place your upgrade scripts here
-	 * Remember that once it has been added it cannot be removed!
-	 */
-	// function (context, props) {
-	// 	return {
-	// 		updatedConfig: null,
-	// 		updatedActions: [],
-	// 		updatedFeedbacks: [],
-	// 	}
-	// },
+	function (_context, props) {
+		const updatedActions = []
+
+		for (const action of props.actions) {
+			if (action.actionId === 'shell_command') {
+				if (action.options.mode === undefined) {
+					action.options.mode = 'cmd_b64'
+					updatedActions.push(action)
+				}
+			}
+		}
+
+		return {
+			updatedConfig: null,
+			updatedActions,
+			updatedFeedbacks: [],
+		}
+	},
 ]


### PR DESCRIPTION

### Summary
This PR enhances the `shell_command` action to resolve Companion variables dynamically and prevent JSON parsing issues and shell quoting conflicts when commands contain quotes, backslashes, or nested JSON structures.

### Key Features & Changes
1. **Variable Parsing**: Dynamically resolves Companion variables before execution (`parseVariablesInString`).
2. **Execution Modes**: Added `mode` dropdown in `shell_command`:
   - `cmd_b64` (default): Encapsulates command via a PowerShell Base64 wrapper executing `cmd.exe /c`, supporting `%USERPROFILE%`, quotes, and redirects on Windows natively.
   - `powershell_b64`: Encapsulates command via `powershell -NoProfile -NonInteractive -EncodedCommand <UTF16LE_Base64>` for PowerShell syntax ($env).
   - `bash_b64`: Encapsulates command via `echo <UTF8_Base64> | base64 -d | bash` for macOS/Linux.
   - `direct`: Raw unencoded command execution.
3. **Migration & Retro-compatibility**: Added a static upgrade script in `upgrades.ts` so existing user instances and action configurations upgrade seamlessly.
4. **UX**: Added tooltips (`?` icon) and detailed field descriptions in the Companion UI.
5. **Listener Compatibility**: Works out-of-the-box with closed-source Listener clients without requiring client-side updates.

### Verification & Testing
- **Windows**: Extensively tested CMD Base64 (`cmd_b64`) with `%USERPROFILE%`, quotes, backslashes, and file redirects. Tested PowerShell Base64 (`powershell_b64`) with WinForms GUI dialogs.
- **macOS / Linux**: The `bash_b64` pipeline is implemented following standard POSIX base64 conventions (`echo | base64 -d | bash`), but **has not yet been physically tested on Unix/macOS environments**.
- Verified TypeScript build (`npm run build`) and formatting (`npm run format`).
